### PR TITLE
feat: vault agents — seed-worker, gardener, reviewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Specialized subagents that can be dispatched for focused tasks:
 
 | Agent | What it does |
 |-------|-------------|
-| `vault-seed-worker` | Bulk-writes pre-approved notes (dispatched by vault-seed Phase 3) |
+| `vault-seed-worker` | Bulk-writes a pre-approved note list for a project (used by vault-seed) |
 | `vault-gardener` | Background maintenance — links orphans, fills frontmatter gaps, syncs indexes |
 | `vault-reviewer` | Reviews recently written notes for quality, accuracy, and linking |
 

--- a/agents/vault-gardener.md
+++ b/agents/vault-gardener.md
@@ -19,14 +19,14 @@ You are a vault maintenance agent. Your job is to keep the Claudian vault health
 ### Orphan Notes
 Find notes with no inbound `[[wikilinks]]` from other notes.
 
-**Auto-fix:** For each orphan, search for related notes by tag overlap and content similarity. If a strong match exists, add a `[[wikilink]]` in the related note's body and update both notes' `links-to` frontmatter.
+**Auto-fix:** For each orphan, search for related notes by tag overlap. A strong match requires at least 2 overlapping tags AND the orphan's title or a key term from its title appears in the candidate note's body. If matched, add a `[[wikilink]]` in the related note's body and update both notes' `links-to` frontmatter.
 
 **Report only:** If no strong match exists, list the orphan for the user to decide.
 
 ### Missing Links
 Find notes that reference concepts covered by other notes but don't link to them.
 
-**Auto-fix:** Add `[[wikilinks]]` where the connection is clear (e.g., a note mentions "session locking" and a note titled "Session Locking in DataStores" exists).
+**Auto-fix:** Only auto-link when a candidate note's title appears verbatim or near-verbatim in the body of the source note (e.g., a note mentions "Session Locking in DataStores" and that note exists). Everything else goes to the report.
 
 ### Stale Content
 Find notes where `updated` is older than 30 days and the note is still referenced by other notes.
@@ -36,7 +36,7 @@ Find notes where `updated` is older than 30 days and the note is still reference
 ### Frontmatter Gaps
 Find notes missing required fields: title, type, project, source, tags, created, updated.
 
-**Auto-fix:** If the missing field can be inferred (e.g., `type` from the folder, `project` from the path, `created` from git history or filesystem), fill it in. Otherwise report it.
+**Auto-fix:** If the missing field can be inferred (e.g., `type` from the folder, `project` from the path, `created` from git history), fill it in. Do not infer `created` from filesystem timestamps — they are unreliable on Windows. Otherwise report it.
 
 ### Project Index Sync
 Check that each project's `index.md` links to all notes in that project's folder.

--- a/agents/vault-reviewer.md
+++ b/agents/vault-reviewer.md
@@ -20,7 +20,7 @@ For each note, check:
 
 ### Frontmatter Quality
 - All required fields present: title, type, project, source, tags, created, updated
-- Type is valid: knowledge, architecture, idea, spec, pattern, gotcha
+- Type is valid: knowledge, architecture, spec, pattern, gotcha
 - Source is valid: claude, human, extracted
 - Visibility is valid: project-only, cross-project
 - Tags are meaningful (not generic like "misc" or "other")
@@ -40,16 +40,16 @@ For each note, check:
 
 ### File Quality
 - Filename is kebab-case derived from title
-- File is in the correct folder per type routing rules
+- File is in the correct folder: `knowledge` → `knowledge/`, `architecture` → `architecture/`, `spec`/`pattern`/`gotcha` → `knowledge/`, project-specific → `projects/{name}/`
 - No duplicate notes with the same or very similar titles
 
 ## Output
 
 Per note:
 ```
-✅ knowledge/api-rate-limiting.md — clean
-⚠️ architecture/data-flow.md — missing link to [[Module Map]], tags too generic
-❌ knowledge/debug-notes.md — appears to be session ephemera, not durable knowledge
+[OK]   knowledge/api-rate-limiting.md — clean
+[WARN] architecture/data-flow.md — missing link to [[Module Map]], tags too generic
+[FLAG] knowledge/debug-notes.md — appears to be session ephemera, not durable knowledge
 ```
 
 Summary:
@@ -57,12 +57,12 @@ Summary:
 Reviewed: 8 notes
 Clean: 6
 Warnings: 1 (fixable)
-Rejected: 1 (should be removed or rewritten)
+Flagged: 1 (needs rewrite or removal — requires human confirmation)
 ```
 
 ## Rules
 
-- Do not modify notes yourself — report findings for the parent session or vault-gardener to act on
+- Do not modify notes yourself — report findings for the parent session to act on
 - Be strict about ephemera — if it reads like a session log, flag it
 - Be lenient about style — if the content is durable and accurate, minor formatting issues are warnings not rejections
 - Check wikilink targets actually exist before flagging missing links

--- a/agents/vault-seed-worker.md
+++ b/agents/vault-seed-worker.md
@@ -39,7 +39,7 @@ For each note in the list:
 
 3. Write the file to `{vault}/{folder}/{filename}`.
 
-4. After all notes are written, update the project index at `{vault}/projects/{project}/index.md` — append wikilinks under the `## Notes` section. Do not replace existing links.
+4. After all notes are written, update the project index at `{vault}/projects/{project}/index.md` — append wikilinks under the existing `## Notes` section. Do not replace existing links. If no `## Notes` section exists, create it.
 
 5. Report what was created: list every file path written.
 
@@ -49,4 +49,6 @@ For each note in the list:
 - Do NOT propose changes to the note list — it's already approved
 - Do NOT skip notes or modify their content beyond filling in the template
 - Do NOT create notes outside the vault path
+- Always write `source: claude` regardless of what the input payload says
+- Omit `relevant-to` and `links-to` from frontmatter when they are empty — do not write empty arrays
 - If a file already exists at the target path, skip it and report it as skipped


### PR DESCRIPTION
## Summary

Three specialized subagents for vault operations:

- **vault-seed-worker** — dispatched by vault-seed Phase 3 to bulk-write pre-approved notes. Offloads 8-10 Write tool calls from the main session's context window.
- **vault-gardener** — background maintenance agent. Links orphan notes, fills frontmatter gaps, syncs project indexes. Auto-fixes what it can, reports what needs human judgment.
- **vault-reviewer** — quality reviewer for recently written notes. Checks frontmatter completeness, content accuracy, wikilink validity, and ephemera detection. Reports findings without modifying notes.

## Test plan

- [x] All 48 existing tests pass
- [ ] Manual test: dispatch vault-seed-worker with a pre-built note list
- [ ] Manual test: run vault-gardener on a vault with known orphans
- [ ] Manual test: run vault-reviewer on recently seeded notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)