### PR TITLE
fix: enforce dangling wikilink anti-pattern in vault-seed and vault-stub

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
 
   "metadata": {
     "description": "Obsidian vault as Claude's second brain. Persistent, structured, interlinked knowledge across all your projects.",
-    "version": "0.1.6"
+    "version": "0.1.7"
   },
 
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Obsidian vault as Claude's second brain. Persistent, structured, interlinked knowledge across all your projects.",
   "author": {
     "name": "CyanoTex"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,26 +76,63 @@ can't enforce: how you think, how you plan, how you manage context.
 
 ## Project: Claudian
 
-Claudian lives in the gap between Obsidian and Claude Code. The ecosystem
-today is fragmented — 20+ MCP servers, none canonical; no bidirectional
-sync; nothing in the official plugin registry. Scope and direction are
-still being defined. Update this section as the vision solidifies.
+Claudian is a Claude Code plugin that turns an Obsidian vault into a
+persistent, structured knowledge layer across all projects. Hooks inject
+vault context automatically; skills write/search/maintain notes; agents
+handle bulk operations. The vault is plain markdown with YAML frontmatter,
+readable by both Claude and Obsidian.
+
+### Commands
+
+```bash
+npm test          # vitest run (all tests)
+npm run test:watch # vitest in watch mode
+```
+
+### Directory Structure
+
+```
+core/        Agent-agnostic modules (config, frontmatter, quality-gate, relevance, resolver)
+hooks/       SessionStart + UserPromptSubmit runners, hooks.json config, run-hook.cmd wrapper
+skills/      Skill definitions (vault-write, vault-search, vault-seed, etc.)
+agents/      Subagent definitions (vault-gardener, vault-reviewer, vault-seed-worker)
+templates/   Note templates (architecture, gotcha, knowledge, pattern, spec)
+tests/       Vitest suites — mirrors core/ and hooks/ structure
+production/  Runtime artifacts (session-logs/, gitignored)
+```
+
+Key architecture decisions:
+- Two-layer design: agent-agnostic core + thin Claude Code adapter
+- SessionStart builds index and writes cache pointer; UserPromptSubmit
+  reads pointer using only Node builtins (no external deps in hot path)
+- Quality gate prevents ephemera from entering the vault
+- Capability escalation: filesystem always, claudy-talky/Obsidian CLI/
+  claude-mem when available
+
+Plugin distribution: marketplace at CyanoTex/claudian. Version must bump
+in all 3 files for cache refresh — CI enforces this on PRs:
+- `package.json` (root)
+- `.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json`
 
 ## Dependencies & Stack
 
+- ESM (`"type": "module"` in package.json). Node >=18.
+- Runtime dep: js-yaml (frontmatter parsing).
+- Dev dep: vitest (test runner).
+- Hooks must use Node builtins only — no external imports (CI enforces).
 - Document every dependency choice and why. No silent `npm install`.
-- Prefer small, well-maintained packages over kitchen-sink frameworks.
 - Pin versions. Lock files are not optional.
 
 ## Architecture Decisions
 
-- Record non-obvious architectural decisions inline in an `adr/` folder
-  using lightweight ADR format (context, decision, consequences). One file
-  per decision. These outlast memory and comments.
+- Record non-obvious architectural decisions in `adr/` (created on first
+  entry) using lightweight ADR format (context, decision, consequences).
+  One file per decision.
 - When two reasonable approaches exist: present both with tradeoffs. Don't
   pick silently.
 
 ## Gotchas Log
 
-- Maintained in `gotchas.md` per the Self-Correction section above.
-  Created on first entry, not preemptively.
+- Maintained in `gotchas.md` (created on first entry, not preemptively)
+  per the Self-Correction section above.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Every note has typed frontmatter with tags, project scope, and visibility settin
 | `/vault-link` | Find and create connections between notes |
 | `/vault-status` | Vault health dashboard — orphans, stale notes, coverage |
 | `/vault-seed` | Bulk-create a project's initial knowledge base from codebase analysis |
-| `/vault-stub` | Find broken wikilinks and create stub notes for them |
+| `/vault-stub` | Find broken wikilinks and coordinate resolution with project-context sessions |
 | `/claudian-init` | First-run setup |
 
 ## Agents

--- a/agents/vault-seed-worker.md
+++ b/agents/vault-seed-worker.md
@@ -35,11 +35,11 @@ For each note in the list:
    ---
    ```
 
-2. Write the body using the template structure. Include `[[wikilinks]]` to other notes in the batch where referenced.
+2. Write the body using the template structure. Only `[[wikilink]]` to notes that already exist in the vault or were written earlier in this batch. Never link to planned-but-unwritten notes.
 
 3. Write the file to `{vault}/{folder}/{filename}`.
 
-4. After all notes are written, update the project index at `{vault}/projects/{project}/index.md` — append wikilinks under the existing `## Notes` section. Do not replace existing links. If no `## Notes` section exists, create it.
+4. After all notes are written, update the project index at `{vault}/projects/{project}/index.md` — the index is always the **last file written**. Append wikilinks under `## Notes`, but only for notes that were actually created. Drop any note that was skipped or failed. Do not replace existing links. Create the section if absent.
 
 5. Report what was created: list every file path written.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Obsidian vault as Claude's second brain — a Claude Code plugin for persistent, structured, interlinked knowledge.",
   "type": "module",
   "scripts": {

--- a/skills/vault-seed/SKILL.md
+++ b/skills/vault-seed/SKILL.md
@@ -85,7 +85,7 @@ links-to: [{titles of other notes in this batch that this note references}]
 - Cross-project notes: set `project: cross-project`, populate `relevant-to` with at minimum the current project
 - Populate `links-to` with other notes in this batch that this note references
 
-3. **Write the body** per the template. Use `[[wikilinks]]` to other batch notes wherever referenced.
+3. **Write the body** per the template. Only `[[wikilink]]` to notes that already exist in the vault or were written earlier in this batch. Never link to planned-but-unwritten notes — see [[Dangling Wikilink Anti-Pattern]].
 
 4. **Name the file** kebab-case from the title, stripping leading articles (a, an, the):
    - "Why We Use CRDT for Sync" → `why-we-use-crdt-for-sync.md`
@@ -98,7 +98,7 @@ links-to: [{titles of other notes in this batch that this note references}]
 
 ### After all notes are written:
 
-6. **Update the project index** at `{vault}/projects/{project-name}/index.md` — append wikilinks to every new note under `## Notes`. Don't replace existing links. Create the section if absent.
+6. **Update the project index** — the index is always the **last file written**. Append wikilinks to `{vault}/projects/{project-name}/index.md` under `## Notes`, but only for notes that were actually created and confirmed. Drop any planned note that wasn't written. Don't replace existing links. Create the section if absent.
 
 ## Phase 4: Verify
 
@@ -133,6 +133,7 @@ Each note must pass before Phase 4 review:
 - **Valid source** — claude (for seed notes)
 - **Valid visibility** — project-only or cross-project
 - **No duplicates** — skip any note whose title already exists; report it as skipped
+- **No dangling wikilinks** — every `[[wikilink]]` in a note body must resolve to an existing vault note or a note written earlier in this batch
 
 ## Re-Running vault-seed
 

--- a/skills/vault-stub/SKILL.md
+++ b/skills/vault-stub/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: vault-stub
 description: This skill should be used when the user asks to "fix broken wikilinks", "create missing notes", "fill grey nodes", "stub out missing notes", "resolve unlinked references", or when Obsidian's graph view shows unresolved nodes after vault-seed or bulk vault-write operations.
-version: 0.1.0
+version: 0.2.0
 ---
 
 # vault-stub
 
-Scan the vault for broken `[[wikilinks]]` — references in body text that point to notes that don't exist — and create stub notes so they become real nodes in Obsidian's graph.
+Scan the vault for broken `[[wikilinks]]` and coordinate with project-context Claude sessions to resolve them with real content — not empty stubs.
+
+vault-stub is a **coordination skill**. It identifies what's missing, then dispatches the actual writing to Claude sessions that have the codebase context to produce meaningful notes. See [[Dangling Wikilink Anti-Pattern]].
 
 ## When to Use
 
@@ -37,17 +39,17 @@ Do not flag these as broken:
 
 ## Phase 2 — Propose
 
-Present unresolved wikilinks grouped by inferred project:
+Present unresolved wikilinks grouped by project:
 
 ```
 Broken wikilinks found:
 
-| # | Wikilink Target          | Referenced By                    | Suggested Type | Suggested Folder          |
-|---|--------------------------|----------------------------------|----------------|---------------------------|
-| 1 | Session Lock Deep Dive   | projects/osrps/data-flow.md      | knowledge      | projects/osrps/           |
-| 2 | Rate Limiting Gotcha     | knowledge/api-patterns.md        | gotcha         | knowledge/                |
+| # | Wikilink Target          | Referenced By                    | Project   | Inferred Type |
+|---|--------------------------|----------------------------------|-----------|---------------|
+| 1 | Session Lock Deep Dive   | projects/osrps/data-flow.md      | osrps     | knowledge     |
+| 2 | Rate Limiting Gotcha     | knowledge/api-patterns.md        | (cross)   | gotcha        |
 
-Create stubs? Approve, modify, or skip individual entries.
+Approve to dispatch, modify, or skip individual entries.
 ```
 
 **Type inference rules:**
@@ -57,75 +59,59 @@ Create stubs? Approve, modify, or skip individual entries.
 - Target appears in a project-specific note → same project, `knowledge` type
 - Default: `knowledge`
 
-**Folder inference rules:**
-- All referencing notes from one project → `projects/{project}/`
-- Referenced by notes from multiple projects → `knowledge/`
-- Architecture-type stubs → `architecture/`
+**Project inference:**
+- All referencing notes from one project → that project
+- Referenced by notes from multiple projects → cross-project
+- Check `project` frontmatter in referencing notes
 
 Wait for user approval before proceeding.
 
-## Phase 3 — Create Stubs
+## Phase 3 — Dispatch
 
-For each approved stub:
+vault-stub does **not** write notes itself for other projects. It coordinates with Claude sessions that have the codebase context to produce meaningful content.
 
-1. Read the template from `{vault}/meta/templates/` matching the inferred type.
+### Current project (cwd matches a registered project)
 
-2. Assemble frontmatter:
+If broken wikilinks belong to the project you're currently working in, you have the codebase context. Write the notes directly using vault-write, with real content derived from reading the relevant code and docs.
 
-```yaml
----
-title: "{wikilink target text}"
-type: {inferred type}
-project: {inferred project or cross-project}
-source: claude
-tags: [{inferred from referencing notes — shared tags, minimum 1}]
-created: "{today YYYY-MM-DD}"
-updated: "{today YYYY-MM-DD}"
-visibility: {project-only if single project, cross-project if multi}
-links-to: ["{titles of notes that reference this stub}"]
----
-```
+### Other projects
 
-3. Write a minimal body following the template structure, with TODO markers for content:
+1. Use claudy-talky `list_agents` to find Claude sessions running in the relevant project's working directory
+2. **Session found:** Use `handoff_work` to send the note-writing task, including:
+   - The wikilink target (note title)
+   - The inferred type and folder
+   - The referencing notes and their content context (so the target Claude understands what's needed)
+   - Instruction to use vault-write for each note
+3. **No session found:** Report to the user:
+   > "No active session for project {name}. Start a Claude session in {project-path} and ask it to write these notes, or run vault-stub from there."
 
-```markdown
-## Summary
+   Do **not** create empty stubs. An unresolved wikilink is better than an empty note.
 
-Stub — referenced by [[Referencing Note Title]]. Needs content.
+### Never do this
 
-## Details
-
-<!-- TODO: flesh out this stub with vault-write -->
-
-## References
-
-- [[Referencing Note Title]]
-```
-
-For `gotcha` type, use the gotcha template sections (`## The Gotcha`, `## How to Detect`, etc.) with TODO markers.
-For `pattern` type, use the pattern template sections (`## Problem`, `## Solution`, etc.) with TODO markers.
-
-4. Name the file using kebab-case from the wikilink target title, stripping leading articles.
-
-5. Append the new stub to `{vault}/projects/{project}/index.md` under `## Notes`:
-   - `[[Note Title]] — stub, needs content`
-
-6. In the referencing note(s), add the stub's title to `links-to` frontmatter if not already present.
+- Write files with TODO markers or "stub, needs content" placeholders
+- Create 0-byte files to "resolve" graph nodes
+- Write generic placeholder content without codebase context
+- Create notes for projects whose codebase you haven't read
 
 ## Phase 4 — Report
 
 ```
-Created {N} stub notes:
-  projects/osrps/session-lock-deep-dive.md (stub)
-  knowledge/rate-limiting-gotcha.md (stub)
+Resolved {N} broken wikilinks:
 
-Stubs need content — flesh out with vault-write or let vault-gardener flag for review.
+  Current project ({project}):
+    knowledge/session-lock-deep-dive.md — written with content
+
+  Dispatched to other sessions:
+    osrps (agent {id}): 3 notes handed off
+    bloxus: no active session — 2 notes deferred
+
+  Remaining unresolved: {N} (no project session available)
 ```
 
 ## Quality Rules
 
-- Stubs pass the same frontmatter validation as vault-write (required fields, valid enums)
-- Stubs are never cross-project unless referenced by multiple projects
+- Every note written must have real content — no TODO markers, no placeholder text
+- Notes pass the same frontmatter validation as vault-write (required fields, valid enums)
 - Never overwrite an existing note — skip if a file exists at the target path
-- Infer tags from referencing notes' tags (intersection of shared tags, minimum 1)
-- If no tags can be inferred, use the referencing note's project name as a tag
+- An unresolved wikilink is always preferable to an empty or shallow note

--- a/skills/vault-stub/SKILL.md
+++ b/skills/vault-stub/SKILL.md
@@ -76,13 +76,14 @@ If broken wikilinks belong to the project you're currently working in, you have 
 
 ### Other projects
 
-1. Use claudy-talky `list_agents` to find Claude sessions running in the relevant project's working directory
-2. **Session found:** Use `handoff_work` to send the note-writing task, including:
+1. If claudy-talky is unavailable (MCP server not running), treat all other-project wikilinks as "no session found" and skip to step 3.
+2. Use claudy-talky `list_agents` to find Claude sessions running in the relevant project's working directory.
+3. **Session found:** Use `handoff_work` to send the note-writing task, including:
    - The wikilink target (note title)
    - The inferred type and folder
    - The referencing notes and their content context (so the target Claude understands what's needed)
    - Instruction to use vault-write for each note
-3. **No session found:** Report to the user:
+4. **No session found:** Report to the user:
    > "No active session for project {name}. Start a Claude session in {project-path} and ask it to write these notes, or run vault-stub from there."
 
    Do **not** create empty stubs. An unresolved wikilink is better than an empty note.


### PR DESCRIPTION
## Summary

- **vault-seed**: Only wikilink to notes that exist or were written earlier in the batch. Index is always the last file written — unwritten notes get dropped, not linked. New quality gate rule: no dangling wikilinks.
- **vault-stub v0.2.0**: Rewritten as a coordination skill. For the current project, writes notes directly with vault-write. For other projects, dispatches via claudy-talky to sessions with codebase context. Never creates empty stubs — an unresolved wikilink is better than an empty note.
- **CLAUDE.md**: Added commands section, directory structure map, actual stack info (ESM, js-yaml, vitest, Node >=18), precise version file paths. Removed stale open issues list.

Implements the three rules from the [[Dangling Wikilink Anti-Pattern]] ADR.

## Test plan

- [ ] Verify vault-seed wikilink restriction is clear and unambiguous
- [ ] Verify vault-stub Phase 3 dispatch flow covers: current project, other project with session, other project without session
- [ ] Verify vault-stub "never do this" list covers all prior anti-patterns
- [ ] Confirm CLAUDE.md directory structure matches actual repo layout
- [ ] CI passes (version bump 0.1.6 → 0.1.7 in all 3 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)