### PR TITLE
feat: planned wikilinks with deferred resolution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
 
   "metadata": {
     "description": "Obsidian vault as Claude's second brain. Persistent, structured, interlinked knowledge across all your projects.",
-    "version": "0.1.7"
+    "version": "0.1.8"
   },
 
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Obsidian vault as Claude's second brain. Persistent, structured, interlinked knowledge across all your projects.",
   "author": {
     "name": "CyanoTex"

--- a/agents/vault-seed-worker.md
+++ b/agents/vault-seed-worker.md
@@ -1,6 +1,6 @@
 ---
 name: vault-seed-worker
-description: Subagent that bulk-writes vault notes from a pre-approved list. Dispatched by vault-seed Phase 3 to offload file creation from the main session's context window.
+description: Subagent that writes vault notes from approved descriptions. Dispatched by vault-seed Phase 3 with note metadata and codebase context to produce real content.
 model: sonnet
 ---
 
@@ -41,9 +41,9 @@ For each note in the list:
 
 3. Write the file to `{vault}/{folder}/{filename}`.
 
-4. After all notes are written, update the project index at `{vault}/projects/{project}/index.md` — the index is always the **last file written**. Append wikilinks under `## Notes`, but only for notes that were actually created. Drop any note that was skipped or failed. Do not replace existing links. Create the section if absent.
+4. Report what was created: list every file path written.
 
-5. Report what was created: list every file path written.
+Do NOT modify the project index — the parent session already wrote it with planned links that resolve naturally once the note file exists.
 
 ## Rules
 

--- a/agents/vault-seed-worker.md
+++ b/agents/vault-seed-worker.md
@@ -6,13 +6,15 @@ model: sonnet
 
 # vault-seed-worker
 
-You are a focused file-writing agent. You receive a list of vault notes to create and write them all. No analysis, no proposals — that was already done by the parent session.
+You are a focused file-writing agent. You receive one or more vault notes to create and write them. No analysis, no proposals — that was already done by the parent session.
 
 ## Input
 
 You will receive:
 - The vault path
-- A list of notes, each with: title, type, project, tags, visibility, relevant-to, folder, filename, body content, and links-to
+- One or more notes, each with: title, type, project, tags, visibility, relevant-to, folder, filename, and links-to
+- A **description** for each note (from the planned link in the index) — use this as content guidance
+- The **codebase path** — read relevant source files to write notes with real, accurate content
 - The template files to use as a basis (already read by the parent)
 
 ## Your Job
@@ -45,7 +47,7 @@ For each note in the list:
 
 ## Rules
 
-- Do NOT analyze the codebase — that's already done
+- DO read the codebase at the provided path to write accurate, detailed content — the description is a guide, not the content itself
 - Do NOT propose changes to the note list — it's already approved
 - Do NOT skip notes or modify their content beyond filling in the template
 - Do NOT create notes outside the vault path

--- a/hooks/session-start.runner.js
+++ b/hooks/session-start.runner.js
@@ -75,8 +75,11 @@ async function run() {
     try {
       const indexPath = join(vaultPath, 'projects', project, 'index.md');
       const indexContent = await readFile(indexPath, 'utf-8');
-      const body = indexContent.replace(/^---[\s\S]*?---/, '');
-      const wikilinks = [...body.matchAll(/\[\[([^\]]+)\]\]/g)].map(m => m[1]);
+      const body = indexContent
+        .replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '')  // strip frontmatter
+        .replace(/```[\s\S]*?```/g, '');                   // strip code blocks
+      const wikilinks = [...body.matchAll(/\[\[([^\]]+)\]\]/g)]
+        .map(m => m[1].split('|')[0].trim());              // handle [[target|alias]]
       const titles = new Set(index.map(n => n.title.toLowerCase()));
       const planned = wikilinks.filter(w => !titles.has(w.toLowerCase()));
       if (planned.length > 0) {
@@ -85,8 +88,10 @@ async function run() {
         lines.push(`Project index has ${planned.length} planned note(s) not yet created. Run /vault-stub to resolve.`);
         lines.push(``);
       }
-    } catch {
-      // No index file — that's fine
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        warnings.push({ file: `projects/${project}/index.md`, error: err.message });
+      }
     }
   }
 

--- a/hooks/session-start.runner.js
+++ b/hooks/session-start.runner.js
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { writeFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { loadFrom, detectProject } from '../core/config.js';
@@ -68,6 +68,26 @@ async function run() {
     lines.push(`Use vault-search to find more notes or read a specific note by path.`);
   } else {
     lines.push(`No relevant notes found. Use vault-write to start building knowledge.`);
+  }
+
+  // Detect planned links in project index
+  if (project) {
+    try {
+      const indexPath = join(vaultPath, 'projects', project, 'index.md');
+      const indexContent = await readFile(indexPath, 'utf-8');
+      const body = indexContent.replace(/^---[\s\S]*?---/, '');
+      const wikilinks = [...body.matchAll(/\[\[([^\]]+)\]\]/g)].map(m => m[1]);
+      const titles = new Set(index.map(n => n.title.toLowerCase()));
+      const planned = wikilinks.filter(w => !titles.has(w.toLowerCase()));
+      if (planned.length > 0) {
+        lines.push(`## Planned Notes`);
+        lines.push(``);
+        lines.push(`Project index has ${planned.length} planned note(s) not yet created. Run /vault-stub to resolve.`);
+        lines.push(``);
+      }
+    } catch {
+      // No index file — that's fine
+    }
   }
 
   if (warnings.length > 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Obsidian vault as Claude's second brain — a Claude Code plugin for persistent, structured, interlinked knowledge.",
   "type": "module",
   "scripts": {

--- a/skills/vault-seed/SKILL.md
+++ b/skills/vault-seed/SKILL.md
@@ -57,48 +57,56 @@ Do NOT proceed to Phase 3 without explicit approval.
 
 ## Phase 3: Write
 
-Bulk-create all approved notes using the Write tool directly (not vault-write):
+### Step 1: Write the project index first
 
-### For each note:
+Update `{vault}/projects/{project-name}/index.md` under `## Notes` with **planned links** for every approved note. Each entry is a wikilink with an inline description:
 
-1. **Read the template** from `{vault}/meta/templates/` matching the note type. Fall back to the plugin's `templates/` folder. Use the actual file — do not invent structure from memory.
-
-2. **Write complete frontmatter:**
-
-```yaml
----
-title: "{note title}"
-type: {knowledge|architecture|pattern|gotcha|spec}
-project: {project-name|cross-project}
-source: claude
-tags: [{relevant tags}]
-created: "{today YYYY-MM-DD}"
-updated: "{today YYYY-MM-DD}"
-visibility: {project-only|cross-project}
-relevant-to: [{projects this note is relevant to, if cross-project}]
-links-to: [{titles of other notes in this batch that this note references}]
----
+```
+- [[System Architecture Overview]] — overall architecture, filesystem-first design, capability escalation
+- [[Module Map]] — the 5 core modules, their responsibilities, and dependency graph
+- [[Data Flow]] — hook-to-skill data pipeline, cache pointer handoff
 ```
 
-- `source: claude` for all seed notes
-- `visibility: project-only` by default; `cross-project` only for patterns/gotchas that clearly generalize
-- Cross-project notes: set `project: cross-project`, populate `relevant-to` with at minimum the current project
-- Populate `links-to` with other notes in this batch that this note references
+The description explains what the note should contain. Don't replace existing links. Create the section if absent. The index is always written **before** any content notes.
 
-3. **Write the body** per the template. Only `[[wikilink]]` to notes that already exist in the vault or were written earlier in this batch. Never link to planned-but-unwritten notes — see [[Dangling Wikilink Anti-Pattern]].
+### Step 2: Offer each note individually
 
-4. **Name the file** kebab-case from the title, stripping leading articles (a, an, the):
-   - "Why We Use CRDT for Sync" → `why-we-use-crdt-for-sync.md`
-   - "The DataStore Session Lock Pattern" → `datastore-session-lock-pattern.md`
+For each planned link in the index, ask the user:
 
-5. **Place in the correct folder:**
-   - `knowledge`, `spec`, `pattern`, `gotcha` → `{vault}/knowledge/`
-   - `architecture` → `{vault}/architecture/`
-   - Project-internal notes → `{vault}/projects/{project-name}/`
+```
+Create [[System Architecture Overview]]?
+  → overall architecture, filesystem-first design, capability escalation
+  (yes / not now / skip all)
+```
 
-### After all notes are written:
+- **"Yes"** → proceed to Step 3 for this note
+- **"Not now"** → leave the planned link in the index, move to the next note
+- **"Skip all"** → stop offering, leave remaining planned links for a future session
 
-6. **Update the project index** — the index is always the **last file written**. Append wikilinks to `{vault}/projects/{project-name}/index.md` under `## Notes`, but only for notes that were actually created and confirmed. Drop any planned note that wasn't written. Don't replace existing links. Create the section if absent.
+### Step 3: Create the note
+
+For each approved note, dispatch the `vault-seed-worker` agent with:
+
+- The vault path
+- The note's title, type, project, tags, visibility, folder, and filename
+- The **description from the planned link** as content guidance
+- The template file for the note type (read from `{vault}/meta/templates/`, fall back to plugin's `templates/`)
+- The codebase path so the worker can read relevant source files
+
+The worker reads the codebase, writes the note with real content, and reports back.
+
+**Naming:** kebab-case from the title, stripping leading articles (a, an, the):
+- "Why We Use CRDT for Sync" → `why-we-use-crdt-for-sync.md`
+- "The DataStore Session Lock Pattern" → `datastore-session-lock-pattern.md`
+
+**Placement:**
+- `knowledge`, `spec`, `pattern`, `gotcha` → `{vault}/knowledge/`
+- `architecture` → `{vault}/architecture/`
+- Project-internal notes → `{vault}/projects/{project-name}/`
+
+### Step 4: Update the index entry
+
+After the worker confirms the note was written, the planned link in the index is now a real link — no changes needed since the wikilink text is identical. The planned link resolves naturally once the note file exists.
 
 ## Phase 4: Verify
 
@@ -114,14 +122,17 @@ Write → review → fix loop must complete before surfacing results to the user
 **Report after verification passes:**
 
 ```
-Created {N} notes for project "{project-name}":
-  architecture/system-architecture-overview.md
-  architecture/data-flow.md
-  projects/{name}/module-map.md
-  knowledge/error-handling-pattern.md
-  knowledge/session-lock-race-condition.md
+Seeded project "{project-name}":
+  Created {N} notes:
+    architecture/system-architecture-overview.md
+    projects/{name}/module-map.md
+    knowledge/error-handling-pattern.md
 
-Project index updated. All notes passed vault-reviewer.
+  Planned (deferred for later):
+    [[Data Flow]] — hook-to-skill data pipeline, cache pointer handoff
+    [[Session Lock Race Condition]] — gotcha with concurrent session writes
+
+  All created notes passed vault-reviewer.
 ```
 
 ## Quality Gate
@@ -133,7 +144,7 @@ Each note must pass before Phase 4 review:
 - **Valid source** — claude (for seed notes)
 - **Valid visibility** — project-only or cross-project
 - **No duplicates** — skip any note whose title already exists; report it as skipped
-- **No dangling wikilinks** — every `[[wikilink]]` in a note body must resolve to an existing vault note or a note written earlier in this batch
+- **No dangling wikilinks in content notes** — every `[[wikilink]]` in a note body must resolve to an existing vault note or a note written earlier in this batch. Planned links in the index (with ` — ` descriptions) are allowed — see [[Dangling Wikilink Anti-Pattern]]
 
 ## Re-Running vault-seed
 

--- a/skills/vault-seed/SKILL.md
+++ b/skills/vault-seed/SKILL.md
@@ -93,6 +93,12 @@ For each approved note, dispatch the `vault-seed-worker` agent with:
 - The template file for the note type (read from `{vault}/meta/templates/`, fall back to plugin's `templates/`)
 - The codebase path so the worker can read relevant source files
 
+**Frontmatter rules for the dispatch payload:**
+- `source: claude` for all seed notes
+- `visibility: project-only` by default; `cross-project` only for patterns/gotchas that clearly generalize
+- Cross-project notes: set `project: cross-project`, populate `relevant-to` with at minimum the current project
+- Populate `links-to` with titles of existing vault notes this note will reference
+
 The worker reads the codebase, writes the note with real content, and reports back.
 
 **Naming:** kebab-case from the title, stripping leading articles (a, an, the):

--- a/skills/vault-stub/SKILL.md
+++ b/skills/vault-stub/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vault-stub
 description: This skill should be used when the user asks to "fix broken wikilinks", "create missing notes", "fill grey nodes", "stub out missing notes", "resolve unlinked references", or when Obsidian's graph view shows unresolved nodes after vault-seed or bulk vault-write operations.
-version: 0.2.0
+version: 0.3.0
 ---
 
 # vault-stub
@@ -28,6 +28,7 @@ vault-stub is a **coordination skill**. It identifies what's missing, then dispa
 4. Build a title index mapping every existing note title (case-insensitive) and filename to its path
 5. Check each wikilink target against the index for title or filename match
 6. Collect all unresolved targets with the files that reference them
+7. For each unresolved target, check if the referencing line has a description after ` — `. If so, mark it as a **planned link** and capture the description
 
 ### Skip List
 
@@ -39,15 +40,21 @@ Do not flag these as broken:
 
 ## Phase 2 — Propose
 
-Present unresolved wikilinks grouped by project:
+Present unresolved wikilinks grouped by project. Distinguish planned links (have descriptions) from bare broken links:
 
 ```
-Broken wikilinks found:
+Unresolved wikilinks found:
 
+Planned (have descriptions):
+| # | Wikilink Target          | Description                              | Project   | Inferred Type |
+|---|--------------------------|------------------------------------------|-----------|---------------|
+| 1 | System Architecture      | overall architecture, filesystem-first   | claudian  | architecture  |
+| 2 | Module Map               | the 5 core modules and dependency graph  | claudian  | knowledge     |
+
+Bare (no description — may be accidental):
 | # | Wikilink Target          | Referenced By                    | Project   | Inferred Type |
 |---|--------------------------|----------------------------------|-----------|---------------|
-| 1 | Session Lock Deep Dive   | projects/osrps/data-flow.md      | osrps     | knowledge     |
-| 2 | Rate Limiting Gotcha     | knowledge/api-patterns.md        | (cross)   | gotcha        |
+| 3 | Rate Limiting Gotcha     | knowledge/api-patterns.md        | (cross)   | gotcha        |
 
 Approve to dispatch, modify, or skip individual entries.
 ```
@@ -81,6 +88,7 @@ If broken wikilinks belong to the project you're currently working in, you have 
 3. **Session found:** Use `handoff_work` to send the note-writing task, including:
    - The wikilink target (note title)
    - The inferred type and folder
+   - The **description** from the planned link (if available) — this is the primary content guidance
    - The referencing notes and their content context (so the target Claude understands what's needed)
    - Instruction to use vault-write for each note
 4. **No session found:** Report to the user:


### PR DESCRIPTION
## Summary

- **vault-seed**: Index-first flow — writes planned links (wikilink + description) to the project index, then offers each note individually with yes/not now/skip all. Deferred notes stay as planned links for a future session.
- **vault-stub v0.3.0**: Distinguishes planned links (have ` — ` descriptions) from bare broken links. Passes descriptions to writing sessions as content guidance.
- **vault-seed-worker**: Accepts single-note dispatches with description context. Now reads the codebase to write accurate content instead of being fed pre-written body text.
- **SessionStart hook**: Detects unresolved planned links in the project index and nudges "Run /vault-stub to resolve."
- **ADR updated**: Dangling Wikilink Anti-Pattern now has a "Planned Links Exception" — described wikilinks are intentional placeholders, not accidents.

## Test plan

- [ ] vault-seed Phase 3 flow: index written first, per-note approval with yes/not now/skip all
- [ ] vault-stub distinguishes planned links (with descriptions) from bare broken links in Phase 2 table
- [ ] vault-stub passes description to writing session in handoff payload
- [ ] SessionStart hook reports planned note count when project index has unresolved links
- [ ] SessionStart hook stays silent when all index links resolve
- [ ] All 69 existing tests pass (verified locally)
- [ ] Version bump 0.1.7 → 0.1.8 in all 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)