### PR TITLE
fix: reduce UserPromptSubmit hook noise with scored matching

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
 
   "metadata": {
     "description": "Obsidian vault as Claude's second brain. Persistent, structured, interlinked knowledge across all your projects.",
-    "version": "0.1.9"
+    "version": "0.1.10"
   },
 
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Obsidian vault as Claude's second brain. Persistent, structured, interlinked knowledge across all your projects.",
   "author": {
     "name": "CyanoTex"

--- a/docs/superpowers/plans/2026-04-11-hook-noise-reduction.md
+++ b/docs/superpowers/plans/2026-04-11-hook-noise-reduction.md
@@ -1,0 +1,466 @@
+# Hook Noise Reduction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce UserPromptSubmit hook noise by replacing boolean keyword matching with scored relevance matching and a minimum threshold.
+
+**Architecture:** Replace `matchKeywords()` with `scoreMatch()` that returns a numeric score per note. Add a short-message bypass (< 20 chars). Filter by minimum score of 4, sort by score, cap at 3 results. All changes in the hook runner and its test file.
+
+**Tech Stack:** Node.js (ESM, builtins only), Vitest
+
+---
+
+## File Structure
+
+| File | Role |
+|------|------|
+| `hooks/user-prompt-submit.runner.js` | Hook entry point — scored matching, short message bypass, output formatting |
+| `tests/hooks/user-prompt-submit.test.js` | Test suite for new scoring behavior |
+
+No new files. No new dependencies.
+
+---
+
+### Task 1: Write failing tests for `scoreMatch`
+
+**Files:**
+- Modify: `tests/hooks/user-prompt-submit.test.js`
+
+- [ ] **Step 1: Replace the existing `matchKeywords` test block with `scoreMatch` tests**
+
+Replace the entire file content with:
+
+```javascript
+import { describe, it, expect } from 'vitest';
+import { scoreMatch } from '../../hooks/user-prompt-submit.runner.js';
+import { isRelevant } from '../../core/relevance.js';
+
+describe('user-prompt-submit', () => {
+  describe('scoreMatch', () => {
+    it('scores 2 points per title word match (5+ chars, whole-word)', () => {
+      const note = {
+        title: 'DataStore Locking Pattern',
+        tags: ['concurrency'],
+        relPath: 'knowledge/datastore.md',
+      };
+      // "datastore" (9 chars) matches, "locking" (7 chars) matches = 4 pts
+      // Tag "concurrency" does NOT appear in message, so no tag score
+      const score = scoreMatch('How does datastore locking work?', note);
+      expect(score).toBe(4);
+    });
+
+    it('ignores title words under 5 characters', () => {
+      const note = {
+        title: 'App Architecture',
+        tags: ['architecture'],
+        relPath: 'projects/my-game/arch.md',
+      };
+      // "App" is 3 chars — ignored. Only "architecture" (12 chars) matches = 2 pts
+      const score = scoreMatch('Explain the app architecture', note);
+      expect(score).toBe(5); // 2 (title "architecture") + 3 (tag "architecture")
+    });
+
+    it('scores 3 points per tag match', () => {
+      const note = {
+        title: 'Error Handling Pattern',
+        tags: ['errors', 'patterns'],
+        relPath: 'knowledge/errors.md',
+      };
+      // Tag "errors" (6 chars) matches = 3 pts
+      const score = scoreMatch('We keep seeing errors in production', note);
+      expect(score).toBe(3);
+    });
+
+    it('returns 0 for no matches', () => {
+      const note = {
+        title: 'DataStore Locking Pattern',
+        tags: ['datastore', 'concurrency'],
+        relPath: 'knowledge/datastore.md',
+      };
+      const score = scoreMatch('What is the weather today?', note);
+      expect(score).toBe(0);
+    });
+
+    it('uses whole-word matching, not substring', () => {
+      const note = {
+        title: 'Session Management',
+        tags: ['session'],
+        relPath: 'knowledge/session.md',
+      };
+      // "obsession" contains "session" as substring but is a different word
+      const score = scoreMatch('My obsession with clean code', note);
+      expect(score).toBe(0);
+    });
+
+    it('handles hyphenated words in titles', () => {
+      const note = {
+        title: 'Cross-Platform Path Handling',
+        tags: ['paths'],
+        relPath: 'knowledge/cross-platform.md',
+      };
+      // "cross" is 5 chars, "platform" is 8 chars — both match
+      const score = scoreMatch('We need cross platform support', note);
+      expect(score).toBe(4);
+    });
+
+    it('combines title and tag scores', () => {
+      const note = {
+        title: 'DataStore Locking Pattern',
+        tags: ['datastore', 'concurrency'],
+        relPath: 'knowledge/datastore.md',
+      };
+      // "datastore" title match (2) + "datastore" tag match (3) + "concurrency" tag match (3) = 8
+      const score = scoreMatch('datastore concurrency issues', note);
+      expect(score).toBe(8);
+    });
+
+    it('is case-insensitive', () => {
+      const note = {
+        title: 'DataStore Locking Pattern',
+        tags: ['datastore'],
+        relPath: 'knowledge/datastore.md',
+      };
+      const score = scoreMatch('DATASTORE problems', note);
+      expect(score).toBeGreaterThan(0);
+    });
+
+    it('matches hyphenated tags when message contains the hyphenated form', () => {
+      const note = {
+        title: 'Seed Worker Agent',
+        tags: ['vault-seed', 'claude-code'],
+        relPath: 'knowledge/seed-worker.md',
+      };
+      // "vault-seed" preserved as token, matches tag
+      const score = scoreMatch('the vault-seed process is broken', note);
+      expect(score).toBe(3); // 1 tag match
+    });
+
+    it('matches hyphenated title words from non-hyphenated message', () => {
+      const note = {
+        title: 'Cross-Platform Path Handling',
+        tags: ['paths'],
+        relPath: 'knowledge/cross-platform.md',
+      };
+      // Title splits "Cross-Platform" into "cross" + "platform"
+      // Message has "cross" and "platform" as separate words
+      const score = scoreMatch('We need cross platform path handling', note);
+      expect(score).toBe(6); // cross(2) + platform(2) + handling(2)
+    });
+  });
+
+  describe('visibility filtering', () => {
+    const mixedIndex = [
+      { title: 'DataStore Locking', tags: ['datastore'], relPath: 'knowledge/datastore.md', project: 'my-game', visibility: 'project-only', 'relevant-to': [] },
+      { title: 'Shared Pattern', tags: ['datastore'], relPath: 'knowledge/shared.md', project: 'cross-project', visibility: 'cross-project', 'relevant-to': [] },
+      { title: 'Other Game DataStore', tags: ['datastore'], relPath: 'projects/other-game/ds.md', project: 'other-game', visibility: 'project-only', 'relevant-to': [] },
+      { title: 'Linked DataStore Note', tags: ['datastore'], relPath: 'knowledge/linked.md', project: 'other-game', visibility: 'project-only', 'relevant-to': ['my-game'] },
+    ];
+
+    it('filters out project-only notes from other projects', () => {
+      const filtered = mixedIndex.filter(note => isRelevant(note, 'my-game'));
+      const titles = filtered.map(n => n.title);
+      expect(titles).toContain('DataStore Locking');
+      expect(titles).toContain('Shared Pattern');
+      expect(titles).toContain('Linked DataStore Note');
+      expect(titles).not.toContain('Other Game DataStore');
+    });
+
+    it('allows cross-project notes through for any project', () => {
+      const filtered = mixedIndex.filter(note => isRelevant(note, 'unrelated-project'));
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].title).toBe('Shared Pattern');
+    });
+
+    it('excludes all project-only notes when project is null', () => {
+      const filtered = mixedIndex.filter(note => isRelevant(note, null));
+      expect(filtered.every(n => n.visibility === 'cross-project' || n.project === 'cross-project')).toBe(true);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- tests/hooks/user-prompt-submit.test.js`
+
+Expected: FAIL — `scoreMatch` is not exported from the runner (it doesn't exist yet).
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/hooks/user-prompt-submit.test.js
+git commit -m "test: add scoreMatch tests for hook noise reduction"
+```
+
+---
+
+### Task 2: Implement `scoreMatch` and short message bypass
+
+**Files:**
+- Modify: `hooks/user-prompt-submit.runner.js`
+
+- [ ] **Step 1: Replace `matchKeywords` with `scoreMatch` and update `run()`**
+
+Replace the entire file content with:
+
+```javascript
+import { readFile } from 'fs/promises';
+import { cachePointerPath } from '../core/resolver.js';
+
+const MIN_MESSAGE_LENGTH = 20;
+const MIN_SCORE = 4;
+const MAX_SUGGESTIONS = 3;
+
+function isRelevant(note, currentProject) {
+  if (note.project === currentProject) return true;
+  if (note.project === 'cross-project' || note.visibility === 'cross-project') return true;
+  if (note['relevant-to'] && note['relevant-to'].includes(currentProject)) return true;
+  return false;
+}
+
+function tokenize(text) {
+  const raw = text.toLowerCase().split(/[\s.,;:!?()\[\]"']+/).filter(w => w.length > 0);
+  const tokens = new Set();
+  for (const token of raw) {
+    tokens.add(token);
+    if (token.includes('-') || token.includes('_')) {
+      for (const part of token.split(/[-_]+/)) {
+        if (part.length > 0) tokens.add(part);
+      }
+    }
+  }
+  return tokens;
+}
+
+export function scoreMatch(message, note) {
+  const messageWords = tokenize(message);
+  let score = 0;
+
+  const titleWords = note.title.split(/[\s\-_]+/).map(w => w.toLowerCase()).filter(w => w.length >= 5);
+  for (const word of titleWords) {
+    if (messageWords.has(word)) score += 2;
+  }
+
+  for (const tag of note.tags) {
+    if (messageWords.has(tag.toLowerCase())) score += 3;
+  }
+
+  return score;
+}
+
+async function run() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+
+  if (!input.trim()) {
+    emptyOutput();
+    return;
+  }
+
+  let userMessage;
+  try {
+    const parsed = JSON.parse(input);
+    userMessage = parsed.message || parsed.prompt || input;
+  } catch {
+    userMessage = input;
+  }
+
+  if (userMessage.length < MIN_MESSAGE_LENGTH) {
+    emptyOutput();
+    return;
+  }
+
+  const pointerPath = cachePointerPath();
+  let index;
+  try {
+    const cachePath = (await readFile(pointerPath, 'utf-8')).trim();
+    const cached = JSON.parse(await readFile(cachePath, 'utf-8'));
+    const project = cached.project || null;
+    const fullIndex = 'index' in cached ? cached.index : cached;
+    index = fullIndex.filter(note => isRelevant(note, project));
+  } catch {
+    emptyOutput();
+    return;
+  }
+
+  const scored = index
+    .map(note => ({ note, score: scoreMatch(userMessage, note) }))
+    .filter(({ score }) => score >= MIN_SCORE)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_SUGGESTIONS);
+
+  if (scored.length === 0) {
+    emptyOutput();
+    return;
+  }
+
+  const noteList = scored.map(({ note }) => `[[${note.title}]] (${note.relPath})`).join(', ');
+  const context = `[Claudian] Vault may have relevant notes: ${noteList}. Consider vault-search.`;
+
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'UserPromptSubmit',
+      additionalContext: context,
+    },
+  }));
+}
+
+function emptyOutput() {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'UserPromptSubmit',
+      additionalContext: '',
+    },
+  }));
+}
+
+import { pathToFileURL } from 'url';
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  run().catch(() => emptyOutput());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npm test -- tests/hooks/user-prompt-submit.test.js`
+
+Expected: All tests PASS.
+
+- [ ] **Step 3: Run full test suite to check for regressions**
+
+Run: `npm test`
+
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hooks/user-prompt-submit.runner.js tests/hooks/user-prompt-submit.test.js
+git commit -m "feat: replace keyword matching with scored relevance in UserPromptSubmit
+
+Addresses field feedback from OSRPS and RCCS agents. Changes:
+- scoreMatch() with 2pts/title-word + 3pts/tag, whole-word matching
+- Minimum 5-char words for title matching (up from 3)
+- Minimum score threshold of 4 (requires 2+ matches)
+- Short message bypass (< 20 chars)
+- Cap reduced from 5 to 3 suggestions, sorted by score"
+```
+
+---
+
+### Task 3: Add edge case tests
+
+**Files:**
+- Modify: `tests/hooks/user-prompt-submit.test.js`
+
+- [ ] **Step 1: Add short message and integration-style tests**
+
+Add the following `describe` block after the `scoreMatch` block (before `visibility filtering`):
+
+```javascript
+  describe('short message bypass', () => {
+    it('scores normally for messages >= 20 chars', () => {
+      const note = {
+        title: 'DataStore Locking Pattern',
+        tags: ['datastore'],
+        relPath: 'knowledge/datastore.md',
+      };
+      // 31 chars — above threshold
+      const score = scoreMatch('How does datastore locking work', note);
+      expect(score).toBeGreaterThan(0);
+    });
+
+    it('scoreMatch still works on short messages (bypass is in run())', () => {
+      const note = {
+        title: 'Error Handling',
+        tags: ['errors'],
+        relPath: 'knowledge/errors.md',
+      };
+      // scoreMatch itself doesn't enforce length — that's run()'s job
+      const score = scoreMatch('errors', note);
+      expect(score).toBe(3); // tag match
+    });
+  });
+
+  describe('threshold filtering', () => {
+    it('single generic title word scores below threshold', () => {
+      const note = {
+        title: 'Dangling Wikilink Anti-Pattern',
+        tags: ['obsidian', 'wikilinks', 'vault-seed'],
+        relPath: 'architecture/dangling-wikilink-anti-pattern.md',
+      };
+      // Only "pattern" matches (2 pts) — below threshold of 4
+      const score = scoreMatch('check the pattern for this feature', note);
+      expect(score).toBeLessThan(4);
+    });
+
+    it('two specific words meet threshold', () => {
+      const note = {
+        title: 'Dangling Wikilink Anti-Pattern',
+        tags: ['obsidian', 'wikilinks', 'vault-seed'],
+        relPath: 'architecture/dangling-wikilink-anti-pattern.md',
+      };
+      // "dangling" (2) + "wikilink" (2) = 4, meets threshold
+      const score = scoreMatch('fix the dangling wikilink issue', note);
+      expect(score).toBeGreaterThanOrEqual(4);
+    });
+
+    it('tag plus title word exceeds threshold', () => {
+      const note = {
+        title: 'Plugin Cache Versioning Gotcha',
+        tags: ['plugin', 'cache', 'versioning'],
+        relPath: 'knowledge/plugin-cache-versioning-gotcha.md',
+      };
+      // "plugin" title (2) + "plugin" tag (3) + "cache" tag (3) = 8
+      const score = scoreMatch('the plugin cache is stale', note);
+      expect(score).toBeGreaterThanOrEqual(4);
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npm test -- tests/hooks/user-prompt-submit.test.js`
+
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/hooks/user-prompt-submit.test.js
+git commit -m "test: add edge case and threshold tests for scored matching"
+```
+
+---
+
+### Task 4: Version bump
+
+**Files:**
+- Modify: `package.json`
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+
+All three files must be bumped together (CI enforces this).
+
+- [ ] **Step 1: Bump patch version in all three files**
+
+Bump from current version to next patch version in:
+- `package.json` → `"version"` field
+- `.claude-plugin/plugin.json` → `"version"` field
+- `.claude-plugin/marketplace.json` → `"version"` field
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `npm test`
+
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json
+git commit -m "chore: bump version to 0.1.X for hook noise reduction"
+```

--- a/docs/superpowers/specs/2026-04-11-hook-noise-reduction-design.md
+++ b/docs/superpowers/specs/2026-04-11-hook-noise-reduction-design.md
@@ -1,0 +1,65 @@
+# Hook Noise Reduction — Design Spec
+
+**Date:** 2026-04-11
+**Feedback source:** Field reports from OSRPS and RCCS agents (see vault: Field Feedback — April 2026)
+
+## Problem
+
+UserPromptSubmit hook fires vault note suggestions on nearly every message, regardless of relevance. Two independent agents confirmed they've learned to mentally skip the suggestions, which means genuinely relevant ones get missed too.
+
+Root cause: `matchKeywords()` in `user-prompt-submit.runner.js` uses substring matching with a 3-char minimum word length. Any note with a common title word (e.g., "design", "pattern", "plugin", "system") matches casual messages. No scoring, no threshold — a single generic word triggers the suggestion.
+
+## Design
+
+### Change 1: Short message bypass
+
+Messages under 20 characters return empty output immediately. Handles "yes", "do it", "go ahead", "push", etc.
+
+### Change 2: Replace `matchKeywords()` with `scoreMatch()`
+
+New exported function `scoreMatch(message, note)` returns a numeric relevance score:
+
+- **Title word matching:** Split title on word boundaries (`/[\s\-_]+/`), require 5+ chars (up from 3), whole-word match via Set lookup instead of substring. Each match = **2 points**.
+- **Tag matching:** Each tag found in message words = **3 points**. Tags are intentionally specific, so they get higher weight.
+- Message is split into word tokens via `/[\s\-_.,;:!?()\[\]"']+/`.
+
+Minimum score threshold: **4 points**. This requires at least:
+- 2 title word matches (2+2=4), or
+- 1 tag + 1 title word (3+2=5), or
+- 2 tag matches (3+3=6)
+
+A single generic word can never trigger a suggestion.
+
+### Change 3: Sort by score, reduce cap
+
+- Sort matched notes by score descending.
+- Reduce cap from 5 to 3 suggestions per message.
+
+### Change 4: Export `scoreMatch` for testing
+
+Replace `matchKeywords` export with `scoreMatch`. Update test file to use the new function.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `hooks/user-prompt-submit.runner.js` | Replace `matchKeywords()` with scored matching, add short message bypass |
+| `tests/hooks/user-prompt-submit.test.js` | Rewrite tests for new scoring behavior |
+
+## Test Cases
+
+1. Short messages ("yes", "do it") return no suggestions
+2. Messages with one generic word (e.g., "check the pattern") below threshold return no suggestions
+3. Messages with 2+ specific words matching a note return that note
+4. Tag matches score higher than title matches
+5. Results are sorted by score descending
+6. Maximum 3 results returned
+7. Existing visibility filtering still works (project-only, cross-project, relevant-to)
+8. Empty message returns no suggestions
+9. Edge case: message contains tag as substring of a larger word — should NOT match (whole-word only)
+
+## Non-Goals
+
+- Changing SessionStart hook behavior (it surfaces a one-time table, not per-message)
+- Adding a stopword list (5-char minimum + whole-word matching handles most cases; can add later if needed)
+- Changing the note index format or caching strategy

--- a/hooks/user-prompt-submit.runner.js
+++ b/hooks/user-prompt-submit.runner.js
@@ -1,6 +1,10 @@
 import { readFile } from 'fs/promises';
 import { cachePointerPath } from '../core/resolver.js';
 
+const MIN_MESSAGE_LENGTH = 20;
+const MIN_SCORE = 4;
+const MAX_SUGGESTIONS = 3;
+
 function isRelevant(note, currentProject) {
   if (note.project === currentProject) return true;
   if (note.project === 'cross-project' || note.visibility === 'cross-project') return true;
@@ -8,21 +12,34 @@ function isRelevant(note, currentProject) {
   return false;
 }
 
-export function matchKeywords(message, index) {
-  const messageLower = message.toLowerCase();
-  const matched = new Map();
-
-  for (const note of index) {
-    const titleWords = note.title.toLowerCase().split(/\s+/).filter(w => w.length > 3);
-    const titleMatch = titleWords.some(word => messageLower.includes(word));
-    const tagMatch = note.tags.some(tag => messageLower.includes(tag.toLowerCase()));
-
-    if (titleMatch || tagMatch) {
-      matched.set(note.relPath, note);
+function tokenize(text) {
+  const raw = text.toLowerCase().split(/[\s.,;:!?()\[\]"']+/).filter(w => w.length > 0);
+  const tokens = new Set();
+  for (const token of raw) {
+    tokens.add(token);
+    if (token.includes('-') || token.includes('_')) {
+      for (const part of token.split(/[-_]+/)) {
+        if (part.length > 0) tokens.add(part);
+      }
     }
   }
+  return tokens;
+}
 
-  return Array.from(matched.values());
+export function scoreMatch(message, note) {
+  const messageWords = tokenize(message);
+  let score = 0;
+
+  const titleWords = note.title.split(/[\s\-_]+/).map(w => w.toLowerCase()).filter(w => w.length >= 5);
+  for (const word of titleWords) {
+    if (messageWords.has(word)) score += 2;
+  }
+
+  for (const tag of note.tags) {
+    if (messageWords.has(tag.toLowerCase())) score += 3;
+  }
+
+  return score;
 }
 
 async function run() {
@@ -44,7 +61,11 @@ async function run() {
     userMessage = input;
   }
 
-  // Read the active cache pointer written by SessionStart
+  if (userMessage.length < MIN_MESSAGE_LENGTH) {
+    emptyOutput();
+    return;
+  }
+
   const pointerPath = cachePointerPath();
   let index;
   try {
@@ -58,14 +79,18 @@ async function run() {
     return;
   }
 
-  const matches = matchKeywords(userMessage, index);
+  const scored = index
+    .map(note => ({ note, score: scoreMatch(userMessage, note) }))
+    .filter(({ score }) => score >= MIN_SCORE)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_SUGGESTIONS);
 
-  if (matches.length === 0) {
+  if (scored.length === 0) {
     emptyOutput();
     return;
   }
 
-  const noteList = matches.slice(0, 5).map(n => `[[${n.title}]] (${n.relPath})`).join(', ');
+  const noteList = scored.map(({ note }) => `[[${note.title}]] (${note.relPath})`).join(', ');
   const context = `[Claudian] Vault may have relevant notes: ${noteList}. Consider vault-search.`;
 
   process.stdout.write(JSON.stringify({
@@ -85,7 +110,6 @@ function emptyOutput() {
   }));
 }
 
-// Only run as main module
 import { pathToFileURL } from 'url';
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {

--- a/hooks/user-prompt-submit.runner.js
+++ b/hooks/user-prompt-submit.runner.js
@@ -13,7 +13,7 @@ function isRelevant(note, currentProject) {
 }
 
 function tokenize(text) {
-  const raw = text.toLowerCase().split(/[\s.,;:!?()\[\]"']+/).filter(w => w.length > 0);
+  const raw = text.toLowerCase().split(/[\s.,;:!?()\[\]"'`#@/{}]+/).filter(w => w.length > 0);
   const tokens = new Set();
   for (const token of raw) {
     tokens.add(token);
@@ -74,7 +74,10 @@ async function run() {
     const project = cached.project || null;
     const fullIndex = 'index' in cached ? cached.index : cached;
     index = fullIndex.filter(note => isRelevant(note, project));
-  } catch {
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      process.stderr.write(`[Claudian] Cache read failed: ${err.message}\n`);
+    }
     emptyOutput();
     return;
   }
@@ -113,5 +116,8 @@ function emptyOutput() {
 import { pathToFileURL } from 'url';
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
-  run().catch(() => emptyOutput());
+  run().catch(err => {
+    process.stderr.write(`[Claudian] UserPromptSubmit error: ${err.message}\n`);
+    emptyOutput();
+  });
 }

--- a/hooks/user-prompt-submit.runner.js
+++ b/hooks/user-prompt-submit.runner.js
@@ -76,7 +76,7 @@ async function run() {
     index = fullIndex.filter(note => isRelevant(note, project));
   } catch (err) {
     if (err.code !== 'ENOENT') {
-      process.stderr.write(`[Claudian] Cache read failed: ${err.message}\n`);
+      process.stderr.write(`[Claudian] Cache read failed: ${err?.message || err}\n`);
     }
     emptyOutput();
     return;
@@ -117,7 +117,7 @@ import { pathToFileURL } from 'url';
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   run().catch(err => {
-    process.stderr.write(`[Claudian] UserPromptSubmit error: ${err.message}\n`);
+    process.stderr.write(`[Claudian] UserPromptSubmit error: ${err?.message || err}\n`);
     emptyOutput();
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Obsidian vault as Claude's second brain — a Claude Code plugin for persistent, structured, interlinked knowledge.",
   "type": "module",
   "scripts": {

--- a/tests/hooks/user-prompt-submit.test.js
+++ b/tests/hooks/user-prompt-submit.test.js
@@ -178,7 +178,7 @@ describe('user-prompt-submit', () => {
         tags: ['plugin', 'cache', 'versioning'],
         relPath: 'knowledge/plugin-cache-versioning-gotcha.md',
       };
-      // "plugin" title (2) + "plugin" tag (3) + "cache" tag (3) = 8
+      // "plugin" title (2) + "cache" title (2) + "plugin" tag (3) + "cache" tag (3) = 10
       const score = scoreMatch('the plugin cache is stale', note);
       expect(score).toBeGreaterThanOrEqual(4);
     });

--- a/tests/hooks/user-prompt-submit.test.js
+++ b/tests/hooks/user-prompt-submit.test.js
@@ -22,9 +22,9 @@ describe('user-prompt-submit', () => {
         tags: ['architecture'],
         relPath: 'projects/my-game/arch.md',
       };
-      // "App" is 3 chars — ignored. Only "architecture" (12 chars) matches = 2 pts
+      // "App" is 3 chars — ignored. "architecture" title match (2) + tag match (3) = 5
       const score = scoreMatch('Explain the app architecture', note);
-      expect(score).toBe(5); // 2 (title "architecture") + 3 (tag "architecture")
+      expect(score).toBe(5);
     });
 
     it('scores 3 points per tag match', () => {

--- a/tests/hooks/user-prompt-submit.test.js
+++ b/tests/hooks/user-prompt-submit.test.js
@@ -115,6 +115,75 @@ describe('user-prompt-submit', () => {
     });
   });
 
+  describe('short message bypass', () => {
+    it('scores normally for messages >= 20 chars', () => {
+      const note = {
+        title: 'DataStore Locking Pattern',
+        tags: ['datastore'],
+        relPath: 'knowledge/datastore.md',
+      };
+      // 31 chars — above threshold
+      const score = scoreMatch('How does datastore locking work', note);
+      expect(score).toBeGreaterThan(0);
+    });
+
+    it('scoreMatch still works on short messages (bypass is in run())', () => {
+      const note = {
+        title: 'Error Handling',
+        tags: ['errors'],
+        relPath: 'knowledge/errors.md',
+      };
+      // scoreMatch itself doesn't enforce length — that's run()'s job
+      const score = scoreMatch('errors', note);
+      expect(score).toBe(3); // tag match
+    });
+
+    it('returns 0 for empty message', () => {
+      const note = {
+        title: 'DataStore Locking Pattern',
+        tags: ['datastore'],
+        relPath: 'knowledge/datastore.md',
+      };
+      const score = scoreMatch('', note);
+      expect(score).toBe(0);
+    });
+  });
+
+  describe('threshold filtering', () => {
+    it('single generic title word scores below threshold', () => {
+      const note = {
+        title: 'Dangling Wikilink Anti-Pattern',
+        tags: ['obsidian', 'wikilinks', 'vault-seed'],
+        relPath: 'architecture/dangling-wikilink-anti-pattern.md',
+      };
+      // Only "pattern" matches (2 pts) — below threshold of 4
+      const score = scoreMatch('check the pattern for this feature', note);
+      expect(score).toBeLessThan(4);
+    });
+
+    it('two specific words meet threshold', () => {
+      const note = {
+        title: 'Dangling Wikilink Anti-Pattern',
+        tags: ['obsidian', 'wikilinks', 'vault-seed'],
+        relPath: 'architecture/dangling-wikilink-anti-pattern.md',
+      };
+      // "dangling" (2) + "wikilink" (2) = 4, meets threshold
+      const score = scoreMatch('fix the dangling wikilink issue', note);
+      expect(score).toBeGreaterThanOrEqual(4);
+    });
+
+    it('tag plus title word exceeds threshold', () => {
+      const note = {
+        title: 'Plugin Cache Versioning Gotcha',
+        tags: ['plugin', 'cache', 'versioning'],
+        relPath: 'knowledge/plugin-cache-versioning-gotcha.md',
+      };
+      // "plugin" title (2) + "plugin" tag (3) + "cache" tag (3) = 8
+      const score = scoreMatch('the plugin cache is stale', note);
+      expect(score).toBeGreaterThanOrEqual(4);
+    });
+  });
+
   describe('visibility filtering', () => {
     const mixedIndex = [
       { title: 'DataStore Locking', tags: ['datastore'], relPath: 'knowledge/datastore.md', project: 'my-game', visibility: 'project-only', 'relevant-to': [] },

--- a/tests/hooks/user-prompt-submit.test.js
+++ b/tests/hooks/user-prompt-submit.test.js
@@ -1,34 +1,117 @@
 import { describe, it, expect } from 'vitest';
-import { matchKeywords } from '../../hooks/user-prompt-submit.runner.js';
+import { scoreMatch } from '../../hooks/user-prompt-submit.runner.js';
 import { isRelevant } from '../../core/relevance.js';
 
 describe('user-prompt-submit', () => {
-  const index = [
-    { title: 'DataStore Locking', tags: ['datastore', 'concurrency'], relPath: 'knowledge/datastore.md', project: 'my-game', visibility: 'project-only', 'relevant-to': [] },
-    { title: 'Error Handling Pattern', tags: ['errors', 'patterns'], relPath: 'knowledge/errors.md', project: 'cross-project', visibility: 'cross-project', 'relevant-to': [] },
-    { title: 'App Architecture', tags: ['architecture', 'game'], relPath: 'projects/my-game/arch.md', project: 'my-game', visibility: 'project-only', 'relevant-to': [] },
-  ];
-
-  describe('matchKeywords', () => {
-    it('matches note titles in user message', () => {
-      const matches = matchKeywords('How does DataStore locking work?', index);
-      expect(matches).toHaveLength(1);
-      expect(matches[0].title).toBe('DataStore Locking');
+  describe('scoreMatch', () => {
+    it('scores 2 points per title word match (5+ chars, whole-word)', () => {
+      const note = {
+        title: 'DataStore Locking Pattern',
+        tags: ['concurrency'],
+        relPath: 'knowledge/datastore.md',
+      };
+      // "datastore" (9 chars) matches, "locking" (7 chars) matches = 4 pts
+      // Tag "concurrency" does NOT appear in message, so no tag score
+      const score = scoreMatch('How does datastore locking work?', note);
+      expect(score).toBe(4);
     });
 
-    it('matches tags in user message', () => {
-      const matches = matchKeywords('We need better error handling here', index);
-      expect(matches.some(m => m.title === 'Error Handling Pattern')).toBe(true);
+    it('ignores title words under 5 characters', () => {
+      const note = {
+        title: 'App Architecture',
+        tags: ['architecture'],
+        relPath: 'projects/my-game/arch.md',
+      };
+      // "App" is 3 chars — ignored. Only "architecture" (12 chars) matches = 2 pts
+      const score = scoreMatch('Explain the app architecture', note);
+      expect(score).toBe(5); // 2 (title "architecture") + 3 (tag "architecture")
     });
 
-    it('returns empty array when nothing matches', () => {
-      const matches = matchKeywords('What is the weather today?', index);
-      expect(matches).toHaveLength(0);
+    it('scores 3 points per tag match', () => {
+      const note = {
+        title: 'Error Handling Pattern',
+        tags: ['errors', 'patterns'],
+        relPath: 'knowledge/errors.md',
+      };
+      // Tag "errors" (6 chars) matches = 3 pts
+      const score = scoreMatch('We keep seeing errors in production', note);
+      expect(score).toBe(3);
     });
 
-    it('deduplicates matches', () => {
-      const matches = matchKeywords('DataStore DataStore DataStore', index);
-      expect(matches).toHaveLength(1);
+    it('returns 0 for no matches', () => {
+      const note = {
+        title: 'DataStore Locking Pattern',
+        tags: ['datastore', 'concurrency'],
+        relPath: 'knowledge/datastore.md',
+      };
+      const score = scoreMatch('What is the weather today?', note);
+      expect(score).toBe(0);
+    });
+
+    it('uses whole-word matching, not substring', () => {
+      const note = {
+        title: 'Session Management',
+        tags: ['session'],
+        relPath: 'knowledge/session.md',
+      };
+      // "obsession" contains "session" as substring but is a different word
+      const score = scoreMatch('My obsession with clean code', note);
+      expect(score).toBe(0);
+    });
+
+    it('handles hyphenated words in titles', () => {
+      const note = {
+        title: 'Cross-Platform Path Handling',
+        tags: ['paths'],
+        relPath: 'knowledge/cross-platform.md',
+      };
+      // "cross" is 5 chars, "platform" is 8 chars — both match
+      const score = scoreMatch('We need cross platform support', note);
+      expect(score).toBe(4);
+    });
+
+    it('combines title and tag scores', () => {
+      const note = {
+        title: 'DataStore Locking Pattern',
+        tags: ['datastore', 'concurrency'],
+        relPath: 'knowledge/datastore.md',
+      };
+      // "datastore" title match (2) + "datastore" tag match (3) + "concurrency" tag match (3) = 8
+      const score = scoreMatch('datastore concurrency issues', note);
+      expect(score).toBe(8);
+    });
+
+    it('is case-insensitive', () => {
+      const note = {
+        title: 'DataStore Locking Pattern',
+        tags: ['datastore'],
+        relPath: 'knowledge/datastore.md',
+      };
+      const score = scoreMatch('DATASTORE problems', note);
+      expect(score).toBeGreaterThan(0);
+    });
+
+    it('matches hyphenated tags when message contains the hyphenated form', () => {
+      const note = {
+        title: 'Seed Worker Agent',
+        tags: ['vault-seed', 'claude-code'],
+        relPath: 'knowledge/seed-worker.md',
+      };
+      // "vault-seed" preserved as token, matches tag
+      const score = scoreMatch('the vault-seed process is broken', note);
+      expect(score).toBe(3); // 1 tag match
+    });
+
+    it('matches hyphenated title words from non-hyphenated message', () => {
+      const note = {
+        title: 'Cross-Platform Path Handling',
+        tags: ['paths'],
+        relPath: 'knowledge/cross-platform.md',
+      };
+      // Title splits "Cross-Platform" into "cross" + "platform"
+      // Message has "cross" and "platform" as separate words
+      const score = scoreMatch('We need cross platform path handling', note);
+      expect(score).toBe(6); // cross(2) + platform(2) + handling(2)
     });
   });
 
@@ -42,8 +125,7 @@ describe('user-prompt-submit', () => {
 
     it('filters out project-only notes from other projects', () => {
       const filtered = mixedIndex.filter(note => isRelevant(note, 'my-game'));
-      const matches = matchKeywords('datastore', filtered);
-      const titles = matches.map(m => m.title);
+      const titles = filtered.map(n => n.title);
       expect(titles).toContain('DataStore Locking');
       expect(titles).toContain('Shared Pattern');
       expect(titles).toContain('Linked DataStore Note');
@@ -52,15 +134,13 @@ describe('user-prompt-submit', () => {
 
     it('allows cross-project notes through for any project', () => {
       const filtered = mixedIndex.filter(note => isRelevant(note, 'unrelated-project'));
-      const matches = matchKeywords('datastore', filtered);
-      expect(matches).toHaveLength(1);
-      expect(matches[0].title).toBe('Shared Pattern');
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].title).toBe('Shared Pattern');
     });
 
     it('excludes all project-only notes when project is null', () => {
       const filtered = mixedIndex.filter(note => isRelevant(note, null));
       expect(filtered.every(n => n.visibility === 'cross-project' || n.project === 'cross-project')).toBe(true);
-      expect(filtered.some(n => n.project === 'other-game' && n['relevant-to'].length === 0)).toBe(false);
     });
   });
 });

--- a/tests/hooks/user-prompt-submit.test.js
+++ b/tests/hooks/user-prompt-submit.test.js
@@ -33,7 +33,7 @@ describe('user-prompt-submit', () => {
         tags: ['errors', 'patterns'],
         relPath: 'knowledge/errors.md',
       };
-      // Tag "errors" (6 chars) matches = 3 pts
+      // Tag "errors" matches = 3 pts
       const score = scoreMatch('We keep seeing errors in production', note);
       expect(score).toBe(3);
     });
@@ -100,6 +100,28 @@ describe('user-prompt-submit', () => {
       // "vault-seed" preserved as token, matches tag
       const score = scoreMatch('the vault-seed process is broken', note);
       expect(score).toBe(3); // 1 tag match
+    });
+
+    it('matches underscored tags when message contains the underscored form', () => {
+      const note = {
+        title: 'Audit Results',
+        tags: ['session_manager'],
+        relPath: 'knowledge/session.md',
+      };
+      // "session_manager" preserved as token, matches tag
+      const score = scoreMatch('check the session_manager output', note);
+      expect(score).toBe(3);
+    });
+
+    it('includes title words at exactly 5 characters', () => {
+      const note = {
+        title: 'Cache',
+        tags: [],
+        relPath: 'knowledge/cache.md',
+      };
+      // "cache" is exactly 5 chars — should match (>= 5, not > 5)
+      const score = scoreMatch('the cache is broken and needs fixing', note);
+      expect(score).toBe(2);
     });
 
     it('matches hyphenated title words from non-hyphenated message', () => {


### PR DESCRIPTION
## Summary

- Replace boolean `matchKeywords()` with scored `scoreMatch()` — 2pts per title word (5+ chars, whole-word), 3pts per tag match, minimum threshold of 4
- Add short message bypass (< 20 chars) to skip "yes", "do it", "go ahead" etc.
- Reduce suggestion cap from 5 to 3, sorted by score descending
- `tokenize()` preserves hyphenated tokens alongside split parts for correct tag matching

## Motivation

Two independent agents (OSRPS and RCCS) reported that UserPromptSubmit suggestions fire on nearly every message with low relevance. Both agents learned to mentally skip suggestions, meaning genuinely relevant ones got missed too.

Root cause: `matchKeywords()` used substring matching with a 3-char minimum word length. Any note with a common title word ("design", "pattern", "plugin") matched casual messages.

## Test plan

- [x] 19 unit tests covering scoring, thresholds, edge cases, visibility filtering
- [x] Full suite: 121/121 passing, no regressions
- [ ] Verify in a real session: short messages produce no suggestions
- [ ] Verify: messages with 1 generic word produce no suggestions
- [ ] Verify: messages with 2+ specific words surface the right notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)