### PR TITLE
feat: vault-graph viewer skill for archived graphify reports

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
 
   "metadata": {
     "description": "Obsidian vault as Claude's second brain. Persistent, structured, interlinked knowledge across all your projects.",
-    "version": "0.1.14"
+    "version": "0.1.15"
   },
 
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Obsidian vault as Claude's second brain. Persistent, structured, interlinked knowledge across all your projects.",
   "author": {
     "name": "CyanoTex"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Obsidian vault as Claude's second brain — a Claude Code plugin for persistent, structured, interlinked knowledge.",
   "type": "module",
   "scripts": {

--- a/skills/vault-graph/SKILL.md
+++ b/skills/vault-graph/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: vault-graph
+description: Summarize an archived graphify knowledge-graph report — cross-cluster bridges, hyperedges, knowledge gaps — and surface Claudian actions. Use when asked about the shape of the vault, ambient connections, or synthesis candidates.
+---
+
+# vault-graph
+
+Render a Claudian-flavored summary of a graphify `GRAPH_REPORT.md` archived under `<vault>/reports/graph-<YYYY-MM-DD>/`. Claudian does not build the graph — graphify does (`pipx install graphifyy`, then `/graphify <vault>` in its own session). This skill reads the archive and translates it into suggested `vault-write` / `vault-link` actions.
+
+## When to Use
+
+- User asks "what's the shape of the vault?" or "any ambient connections I'm missing?"
+- After a fresh graphify run has dropped outputs under `<vault>/reports/graph-*/`
+- Before a synthesis writing session, to surface bridge candidates
+
+## Locating the Report
+
+Default: most recent `<vault>/reports/graph-*/GRAPH_REPORT.md` (sort dirs by name; convention is `graph-YYYY-MM-DD`).
+
+With arg: `/vault-graph <path>` — path may be a `graph-YYYY-MM-DD/` directory or a direct `GRAPH_REPORT.md`.
+
+If nothing matches, see **No Graph Found**.
+
+## Steps
+
+### 1. Read only the sections you need
+
+`GRAPH_REPORT.md` can be ~300 lines. Read with offset/limit — pull only:
+
+- `## Summary` (counts + extraction mix)
+- `## Surprising Connections` (cross-cluster INFERRED bridges)
+- `## Hyperedges` (multi-node pattern families)
+- `## Knowledge Gaps` (isolated nodes + thin communities)
+- `## Suggested Questions` (graph-derived prompts)
+
+Skip `## Communities` — dozens of entries, hundreds of lines, low signal for a summary pass.
+
+### 2. Render the summary
+
+```
+VAULT-GRAPH — graph-<YYYY-MM-DD>
+<N> nodes · <M> edges · <K> communities · <X>% EXTRACTED / <Y>% INFERRED
+
+TOP CROSS-CLUSTER BRIDGES  (synthesis candidates)
+  1. <Node A>  ⟷  <Node B>  [INFERRED · conf <c>]
+     <a-source-path>  →  <b-source-path>
+  2. …
+  (up to 5)
+
+TOP HYPEREDGES  (latent pattern families)
+  1. <label> — <n> nodes  [EXTRACTED|INFERRED · conf]
+  2. …
+  (up to 5)
+
+KNOWLEDGE GAPS
+  <N> isolated nodes (≤1 connection). Examples: <first 3 labels>
+  <T> thin communities (<3 nodes) — consider pruning or enriching
+
+CLAUDIAN ACTIONS
+  - Synthesis candidates: run /vault-write on bridge #1 and #3 — no cross-link exists today.
+  - Orphan hygiene: /vault-link on <isolated-node-X>.
+  - Hyperedge #2 is a real pattern — one /vault-write with links-to for each member.
+```
+
+Populate with real data from the report. If a section has fewer than 5 entries, show what's there; don't invent.
+
+### 3. Offer a follow-up
+
+Pick the single most interesting bridge — the one that crosses the most distant clusters or has the highest INFERRED confidence — and ask:
+
+> "Bridge **<A>** ⟷ **<B>** looks like the strongest synthesis candidate. Want me to draft a `/vault-write` for it?"
+
+If yes, proceed with `vault-write`. If no, stop.
+
+## No Graph Found
+
+If no `<vault>/reports/graph-*/GRAPH_REPORT.md` exists, print:
+
+```
+No graphify report archived in this vault.
+
+To produce one:
+  1. pipx install graphifyy
+  2. graphify claude install   (installs graphify's own Claude Code skill)
+  3. In a Claude Code session: /graphify <vault-path>
+  4. After it finishes (~4–5 min, Claude-orchestrated with token cost),
+     move graphify-out/ into <vault>/reports/graph-<YYYY-MM-DD>/.
+  5. Re-run /vault-graph.
+
+graphify: https://github.com/safishamsi/graphify
+```
+
+Do not try to invoke graphify from this skill. Graphify's pipeline is multi-turn LLM orchestration (detect → parallel subagent extraction → cluster → label → export); it lives in graphify's own skill, not wrapped inside Claudian.

--- a/skills/vault-graph/SKILL.md
+++ b/skills/vault-graph/SKILL.md
@@ -5,7 +5,7 @@ description: Summarize an archived graphify knowledge-graph report — cross-clu
 
 # vault-graph
 
-Render a Claudian-flavored summary of a graphify `GRAPH_REPORT.md` archived under `<vault>/reports/graph-<YYYY-MM-DD>/`. Claudian does not build the graph — graphify does (`pipx install graphifyy`, then `/graphify <vault>` in its own session). This skill reads the archive and translates it into suggested `vault-write` / `vault-link` actions.
+Read an archived graphify `GRAPH_REPORT.md` under `<vault>/reports/graph-<YYYY-MM-DD>/` and translate it into suggested `vault-write` / `vault-link` actions. This skill does not run graphify — see **No Graph Found** for that.
 
 ## When to Use
 
@@ -89,5 +89,3 @@ To produce one:
 
 graphify: https://github.com/safishamsi/graphify
 ```
-
-Do not try to invoke graphify from this skill. Graphify's pipeline is multi-turn LLM orchestration (detect → parallel subagent extraction → cluster → label → export); it lives in graphify's own skill, not wrapped inside Claudian.


### PR DESCRIPTION
## Summary

- Adds `/vault-graph` — a viewer skill that reads the most recent `<vault>/reports/graph-YYYY-MM-DD/GRAPH_REPORT.md` and renders a Claudian-flavored summary (top cross-cluster bridges, hyperedges, knowledge gaps, `vault-write`/`vault-link` suggestions).
- Version bump 0.1.14 → 0.1.15 in all 3 manifest files.

## Why it's a viewer, not a wrapper

The original spec assumed `graphifyy <vault>` was a batch CLI that produces a report. It isn't. Graphify is an LLM-orchestrated pipeline: it installs its own skill (`graphify claude install`) and Claude drives a multi-step extract/cluster/label pipeline using parallel subagents. There's no command to wrap.

The viewer design treats graphify's output as an **artifact-based capability**: Claudian never invokes the tool, only consumes its archived report. This keeps Claudian decoupled from graphify's LLM-orchestration cost and avoids duplicating its pipeline. `architecture/capability-escalation-model.md` (vault) was updated separately to document this pattern as distinct from runtime-detected capabilities.

## Test plan

- [x] `npm test` — 149/149 pass
- [ ] Manual dogfood: `/vault-graph` against `<vault>/reports/graph-2026-04-18/` produces a summary with real bridge/hyperedge/gap data
- [ ] `/vault-graph` with no graph in the vault prints the install + build instructions cleanly (no stack trace)
- [ ] Version bumps are consistent across package.json / plugin.json / marketplace.json (CI enforces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)